### PR TITLE
⬆️ 🤖 - You have a deep interest in all that is artistic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynaconf = ">=3.1.12"
 loguru = ">=0.6"
 ccxt = "^4.2.80"
 capitalcom-python = "0.2.3"
-degiro-connector = "3.0.26"
+degiro-connector = "3.0.27"
 easyoanda = {version ="1.0.19", python = ">=3.11,<4.0"}
 ibind = "0.1.13"
 # ib_insync = "0.9.86"


### PR DESCRIPTION
Auto Release

## Summary by Sourcery

Chores:
- Update the version of the `degiro-connector` dependency from 3.0.26 to 3.0.27.