### PR TITLE
🚀 new version: conversion to uv

### DIFF
--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -1,18 +1,37 @@
+# repos:
+#   - repo: https://github.com/astral-sh/ruff-pre-commit
+#     rev: v0.0.292
+#     hooks:
+#      - id: ruff
+#        args: [--fix, --exit-non-zero-on-fix]
+
+#   - repo: https://github.com/pre-commit/pre-commit-hooks
+#     rev: v4.4.0
+#     hooks:
+#       - id: check-merge-conflict
+#       - id: trailing-whitespace
+
+#   - repo: https://github.com/PyCQA/bandit
+#     rev: '1.7.5'
+#     hooks:
+#     - id: bandit
+#       args: ["-c", "pyproject.toml"]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.11.7
     hooks:
      - id: ruff
        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/bandit
-    rev: '1.7.5'
+    rev: '1.8.3'
     hooks:
     - id: bandit
       args: ["-c", "pyproject.toml"]

--- a/.github/workflows/👷Flow.yml
+++ b/.github/workflows/👷Flow.yml
@@ -9,18 +9,22 @@ on:
 
 jobs:
   lint:
-    uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVLint.yml@main
     secrets: inherit
   test:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVTest.yml@main
     secrets: inherit
   build:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVBuild.yml@main
     secrets: inherit
   release:
     needs: [build, test]
-    uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVRelease.yml@main # Use UV-specific release workflow
     secrets: inherit
 

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,11 +4,15 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+    # uv is not directly supported in tools, install via pip below
+    # uv: "latest"
   jobs:
+    # Install uv after the environment is created
     post_create_environment:
-      - python -m pip install poetry
+      - pip install uv
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs
+      # Install the package with docs extras using uv
+      - uv pip install -e '.[docs]'
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,47 +1,72 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 
-[tool.poetry]
+[project]
 name = "cefi"
 version = "6.0.9"
 description = "A python library, to interact  with Crypto Exchanges (CCXT library) and brokers (IB & Capital.com)"
-authors = ["mraniki <8766259+mraniki@users.noreply.github.com>"]
-license = "MIT License"
+authors = [
+  { name = "mraniki", email = "8766259+mraniki@users.noreply.github.com" },
+]
+license = "MIT"
 readme = "README.md"
 keywords = ["cex, cefi, crypto, exchange, broker"]
-packages = [
-    {include = "cefi"}
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+  "dynaconf>=3.1.12",
+  "loguru>=0.6",
+  "ccxt>=4.2.80",
+  "capitalcom-python==0.2.3",
+  "degiro-connector==3.0.27",
+  'easyoanda==1.0.19; python_version >= "3.11" and python_version < "4.0"',
+  "ibind==0.1.14",
+  # "ib_insync = \"0.9.86\"",
+  # "mt5linux = \"0.1.9\"",
+  "mt5linux_updated==0.0.1",
+  # "pyetrade = {version =\"2.1.0\"}",
 ]
 
 
-[tool.poetry.urls]
+[project.urls]
+"Homepage" = "https://github.com/mraniki/cefi"
 "Changelog" =  "https://github.com/mraniki/cefi/blob/dev/CHANGELOG.rst"
 "Support" =  "https://github.com/mraniki/cefi/discussions"
 "Issues" =  "https://github.com/mraniki/cefi/issues"
 
 
-[tool.poetry.dependencies]
-python = "^3.10"
-dynaconf = ">=3.1.12"
-loguru = ">=0.6"
-ccxt = "^4.2.80"
-capitalcom-python = "0.2.3"
-degiro-connector = "3.0.27"
-easyoanda = {version ="1.0.19", python = ">=3.11,<4.0"}
-ibind = "0.1.14"
-# ib_insync = "0.9.86"
-# mt5linux = "0.1.9"
-mt5linux_updated = "0.0.1"
-# pyetrade = {version ="2.1.0"}
+[project.optional-dependencies]
+dev = [
+  "python-semantic-release>=8.0.8",
+  "ruff~=0.11",
+  "pre-commit~=4.0",
+]
+test = [
+  "pytest~=8.0",
+  "pytest-cov~=6.0",
+  "pytest-asyncio~=0.26",
+  "pytest-mock~=3.11",
+  "pytest-loguru~=0.4",
+]
+docs = [
+  "sphinx==7.4.7",
+  "pydata-sphinx-theme~=0.14",
+  "sphinx-hoverxref~=1.3",
+  "sphinx_copybutton==0.5.2",
+  "myst_parser~=4.0",
+  "sphinx_design~=0.6",
+]
 
+[tool.setuptools]
+packages = ["cefi"]
 
-
-[ tool.poetry.group.dev.dependencies]
-python-semantic-release = ">=8.0.8"
-ruff = "^0.11.0"
-pre-commit = "^4.0.0"
 
 [tool.ruff]
 exclude = [
@@ -51,17 +76,15 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-  "E",  # pycodestyle
-  "F",  # pyflakes
-  "I",  # isort
+  "E",
+  "F",
+  "I",
   "W"
 ]
 
-#ignore = ["E401","F401","F811"]
 fixable = ["ALL"]
 
 [tool.ruff.format]
-# Like Black, use double quotes for strings.
 quote-style = "double"
 
 [tool.pylint.exceptions]
@@ -70,244 +93,6 @@ overgeneral-exceptions = [
     "builtins.Exception",
     "builtins.RuntimeError",
 ]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.0.0"
-pytest-cov = "^6.0.0"
-pytest-asyncio = "^0.26.0"
-pytest-mock = "^3.11.1"
-pytest-loguru = "^0.4.0"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "^7.3.0"
-pydata-sphinx-theme = "^0.15.0"
-sphinx-hoverxref = "^1.3.0"
-sphinx_copybutton = "0.5.2"
-myst_parser = "^3.0.0"
-sphinx_design = "^0.6.0"
-
-
 
 [tool.pytest.ini_options]
 pythonpath = "."
@@ -333,17 +118,13 @@ omit = [
 exclude_dirs = ["tests","docs"]
 skips = ["B101","B104"]
 
-
 [tool.semantic_release]
 upload_to_vcs_release = true
 version_variables = ["cefi/__init__.py:__version__"]
-build_command = "pip install poetry && poetry build"
 commit_parser = "emoji"
 version_toml = [
-   "pyproject.toml:tool.poetry.version",
-   ]
-
-
+   "pyproject.toml:project.version",
+]
 
 [tool.semantic_release.commit_parser_options]
 major_tags = [
@@ -383,8 +164,8 @@ patch_tags = ["fix","bump","Update",
     "🔇",":mute:",
     "🔊",":volume:",
 ]
+
 [tool.semantic_release.changelog]
-# template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate the project build system and dependency management from Poetry to Setuptools and UV.

Build:
- Configure project build using Setuptools instead of Poetry.
- Migrate project metadata and dependencies to the standard `[project]` table in `pyproject.toml` (PEP 621).

CI:
- Update the ReadTheDocs build process to install dependencies using UV.
- Update pre-commit hook dependencies (`ruff`, `pre-commit-hooks`, `bandit`) to newer versions.